### PR TITLE
DTO for Form

### DIFF
--- a/blog/symfony/.php_cs.dist
+++ b/blog/symfony/.php_cs.dist
@@ -1,12 +1,7 @@
-<?php
+yq166e<?php
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
-    ->exclude('config')
-    ->exclude('var')
-    ->exclude('docker')
-    ->exclude('public/build')
-    ->exclude('Migrations')
 ;
 return PhpCsFixer\Config::create()
     ->setFinder($finder)

--- a/blog/symfony/.php_cs.dist
+++ b/blog/symfony/.php_cs.dist
@@ -1,4 +1,4 @@
-yq166e<?php
+<?php
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')

--- a/blog/symfony/config/routes.yaml
+++ b/blog/symfony/config/routes.yaml
@@ -56,6 +56,9 @@ profile:
 app_logout:
     path: /logout
 
+app_register:
+    path: /register
+
 # Other
 routes:
     path: /routes/

--- a/blog/symfony/src/Controller/RegistrationController.php
+++ b/blog/symfony/src/Controller/RegistrationController.php
@@ -2,49 +2,26 @@
 
 namespace App\Controller;
 
-use App\Entity\User;
 use App\Form\DataObjects\RegistrationData;
+use App\Form\Handler\RegistrationFormHandler;
 use App\Form\RegistrationFormType;
 use App\Security\LoginFormAuthenticator;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 
 class RegistrationController extends AbstractController
 {
-    /**
-     * @Route("/register", name="app_register")
-     */
-    public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder, GuardAuthenticatorHandler $guardHandler, LoginFormAuthenticator $authenticator, EntityManagerInterface $entityManager): Response
+    public function register(Request $request, GuardAuthenticatorHandler $guardHandler, LoginFormAuthenticator $authenticator): Response
     {
         $data = new RegistrationData();
         $form = $this->createForm(RegistrationFormType::class, $data);
 
-        $form->handleRequest($request);
+        // TODO DI
+        $formHandler = new RegistrationFormHandler();
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            // до этого было new User('', ''); А теперь Entity всегда валидна как это и должно быть.
-            $user = new User(
-                $data->getUsername(),
-                $data->getEmail()
-            );
-
-            // encode the plain password
-            $user->setPassword(
-                $passwordEncoder->encodePassword(
-                    $user,
-                    $form->get('plainPassword')->getData()
-                )
-            );
-
-            // Внедрил через интерфейс вместо этого: $entityManager = $this->getDoctrine()->getManager();
-            $entityManager->persist($user);
-            $entityManager->flush();
-
+        if ($user = $formHandler->handle($form, $request)) {
             // do anything else you need here, like send an email
 
             return $guardHandler->authenticateUserAndHandleSuccess(

--- a/blog/symfony/src/DomainManager/AccountManager.php
+++ b/blog/symfony/src/DomainManager/AccountManager.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class AccountManager
 {
-    // TODO DI
     /**
      * @var UserPasswordEncoderInterface
      */
@@ -23,6 +22,7 @@ class AccountManager
      */
     private $entityManager;
 
+    // TODO DI
     public function __construct(UserPasswordEncoderInterface $passwordEncoder, EntityManagerInterface $entityManager)
     {
         $this->passwordEncoder = $passwordEncoder;
@@ -45,39 +45,10 @@ class AccountManager
                 $data->getPlainPassword()
             )
         );
-
-        // Внедрил через интерфейс вместо этого: $entityManager = $this->getDoctrine()->getManager();
+        
         $this->entityManager->persist($user);
         $this->entityManager->flush();
 
         return $user;
     }
 }
-
-
-//class AccountManager
-//{
-//    private $entityManager;
-//    private $secureRandom;
-//
-//    public function __construct(
-//        EntityManger $entityManager,
-//        SecureRandomInterface $secureRandom
-//    ) {
-//        $this->entityManager = $entityManager;
-//        $this->secureRandom = $secureRandom;
-//    }
-//
-//    public function createAccount(Account $account)
-//    {
-//        $confirmationCode = $this
-//            ->secureRandom
-//            ->nextBytes(4);
-//
-//        $account
-//            ->setConfirmationCode(md5($confirmationCode));
-//
-//        $this->entityManager->persist($account);
-//        $this->entityManager->flush();
-//    }
-//}

--- a/blog/symfony/src/DomainManager/AccountManager.php
+++ b/blog/symfony/src/DomainManager/AccountManager.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\DomainManager;
+
+use App\Entity\User;
+use App\Form\DataObjects\RegistrationData;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Form\FormInterface;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+class AccountManager
+{
+    // TODO DI
+    /**
+     * @var UserPasswordEncoderInterface
+     */
+    private $passwordEncoder;
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    public function __construct(UserPasswordEncoderInterface $passwordEncoder, EntityManagerInterface $entityManager)
+    {
+        $this->passwordEncoder = $passwordEncoder;
+        $this->entityManager = $entityManager;
+    }
+
+    // User $user
+    public function createAccount(RegistrationData $data): User
+    {
+        // до этого было new User('', ''); А теперь Entity всегда валидна как это и должно быть.
+        $user = new User(
+            $data->getUsername(),
+            $data->getEmail()
+        );
+
+        // encode the plain password
+        $user->setPassword(
+            $this->passwordEncoder->encodePassword(
+                $user,
+                $data->getPlainPassword()
+            )
+        );
+
+        // Внедрил через интерфейс вместо этого: $entityManager = $this->getDoctrine()->getManager();
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}
+
+
+//class AccountManager
+//{
+//    private $entityManager;
+//    private $secureRandom;
+//
+//    public function __construct(
+//        EntityManger $entityManager,
+//        SecureRandomInterface $secureRandom
+//    ) {
+//        $this->entityManager = $entityManager;
+//        $this->secureRandom = $secureRandom;
+//    }
+//
+//    public function createAccount(Account $account)
+//    {
+//        $confirmationCode = $this
+//            ->secureRandom
+//            ->nextBytes(4);
+//
+//        $account
+//            ->setConfirmationCode(md5($confirmationCode));
+//
+//        $this->entityManager->persist($account);
+//        $this->entityManager->flush();
+//    }
+//}

--- a/blog/symfony/src/Entity/User.php
+++ b/blog/symfony/src/Entity/User.php
@@ -5,7 +5,6 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 
 //use Doctrine\Common\Collections\ArrayCollection;
 //use Doctrine\Common\Collections\Collection;
@@ -30,8 +29,6 @@ class User implements UserInterface, \Serializable
 
     /**
      * @ORM\Column(type="string", length=30, unique=true)
-     * Допускаются русские символы (почему никнейм обязательно должен быть на английском?).
-     * @Assert\Regex("/^[а-яА-Яa-zA-ZЁё][а-яА-Яa-zA-Z0-9Ёё]*?([-_.][а-яА-Яa-zA-Z0-9Ёё]+){0,3}$/u")
      */
     private $username;
 
@@ -48,8 +45,6 @@ class User implements UserInterface, \Serializable
 
     /**
      * @ORM\Column(type="string", length=60, unique=true)
-     * @Assert\NotBlank()
-     * @Assert\Email()
      */
     private $email;
 
@@ -121,7 +116,7 @@ class User implements UserInterface, \Serializable
 
     public function getSalt()
     {
-        return null;
+        // not needed when using the "bcrypt" algorithm in security.yaml
     }
 
     public function getRoles(): array
@@ -189,8 +184,13 @@ class User implements UserInterface, \Serializable
 
     /* Other */
 
+    /**
+     * Removes sensitive data from the user.
+     */
     public function eraseCredentials()
     {
+        // например, чтобы не палить пароль (у меня нет plainPassword)
+        // $this->plainPassword = null;
     }
 
     /** @see \Serializable::serialize() */

--- a/blog/symfony/src/Form/DataObjects/RegistrationData.php
+++ b/blog/symfony/src/Form/DataObjects/RegistrationData.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Form\DataObjects;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class RegistrationData
+{
+    // Допускаются русские символы (почему никнейм обязательно должен быть на английском?).
+    /**
+     * @Assert\Regex("/^[а-яА-Яa-zA-ZЁё][а-яА-Яa-zA-Z0-9Ёё]*?([-_.][а-яА-Яa-zA-Z0-9Ёё]+){0,3}$/u")
+     */
+    private $username;
+
+    /**
+     * @Assert\Email()
+     */
+    private $email;
+
+    // TODO если нужен перевод, то передавать message="author.name.not_blank"
+    // https://symfony.com/doc/current/validation/translations.html
+    /**
+     * @Assert\NotBlank(message="Please enter a password")
+     * @Assert\Length(
+     *      min = 3,
+     *      max = 50,
+     *      minMessage = "Your password should be at least {{ limit }} characters",
+     *      maxMessage = "Your password cannot be longer than {{ limit }} characters"
+     * )
+     */
+    private $plainPassword;
+
+    /**
+     * @return mixed
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param mixed $username
+     */
+    public function setUsername($username): void
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param mixed $email
+     */
+    public function setEmail($email): void
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPlainPassword()
+    {
+        return $this->plainPassword;
+    }
+
+    /**
+     * @param mixed $plainPassword
+     */
+    public function setPlainPassword($plainPassword): void
+    {
+        $this->plainPassword = $plainPassword;
+    }
+}

--- a/blog/symfony/src/Form/Handler/RegistrationFormHandler.php
+++ b/blog/symfony/src/Form/Handler/RegistrationFormHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Form\Handler;
+
+use App\DomainManager\AccountManager;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use App\Entity\User;
+
+class RegistrationFormHandler
+{
+    /**
+     * @var AccountManager
+     */
+    private $accountManager;
+
+    // TODO если использовать DI, то можно будет инджектить в конструктор по интерфейсу / классу
+    public function __construct(AccountManager $accountManager)
+    {
+        $this->accountManager = $accountManager;
+    }
+
+    /**
+     * @param FormInterface $form
+     * @param Request $request
+     * @return User | bool
+     */
+    public function handle(FormInterface $form, Request $request)
+    {
+//        if (!$request->isMethod('POST')) {
+//            return false;
+//        }
+//
+//        $form->bind($request);
+//
+//        if (!$form->isValid()) {
+//            return false;
+//        }
+//
+//        $validAccount = $form->getData();
+//
+//        $this->createAccount($validAccount);
+//
+//        return true;
+
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            return false;
+        }
+
+        return $this->accountManager->createAccount(
+            $form->getData()
+        );
+    }
+}

--- a/blog/symfony/src/Form/Handler/RegistrationFormHandler.php
+++ b/blog/symfony/src/Form/Handler/RegistrationFormHandler.php
@@ -27,22 +27,6 @@ class RegistrationFormHandler
      */
     public function handle(FormInterface $form, Request $request)
     {
-//        if (!$request->isMethod('POST')) {
-//            return false;
-//        }
-//
-//        $form->bind($request);
-//
-//        if (!$form->isValid()) {
-//            return false;
-//        }
-//
-//        $validAccount = $form->getData();
-//
-//        $this->createAccount($validAccount);
-//
-//        return true;
-
         $form->handleRequest($request);
 
         if (!$form->isSubmitted() || !$form->isValid()) {

--- a/blog/symfony/src/Form/RegistrationFormType.php
+++ b/blog/symfony/src/Form/RegistrationFormType.php
@@ -3,43 +3,31 @@
 namespace App\Form;
 
 use App\Entity\User;
+use App\Form\DataObjects\RegistrationData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Length;
 
 class RegistrationFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            // по умолчанию походу TextType::class
             ->add('username')
+            // type="email" для input добавилось, значит symfony определяет по "child" параметру что это Email,
+            // не нужно писать EmailType::class вторым аргументов
             ->add('email')
-            ->add('plainPassword', PasswordType::class, [
-                // instead of being set onto the object directly,
-                // this is read and encoded in the controller
-                'mapped' => false,
-                'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a password',
-                    ]),
-                    new Length([
-                        'min' => 3,
-                        'minMessage' => 'Your password should be at least {{ limit }} characters',
-                        // max length allowed by Symfony for security reasons
-                        'max' => 4096,
-                    ]),
-                ],
-            ])
+            // в Entity этого поля нет
+            ->add('plainPassword', PasswordType::class)
         ;
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'data_class' => User::class,
+            'data_class' => RegistrationData::class,
         ]);
     }
 }

--- a/blog/symfony/src/Form/RegistrationFormType.php
+++ b/blog/symfony/src/Form/RegistrationFormType.php
@@ -2,7 +2,6 @@
 
 namespace App\Form;
 
-use App\Entity\User;
 use App\Form\DataObjects\RegistrationData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -19,7 +18,6 @@ class RegistrationFormType extends AbstractType
             // type="email" для input добавилось, значит symfony определяет по "child" параметру что это Email,
             // не нужно писать EmailType::class вторым аргументов
             ->add('email')
-            // в Entity этого поля нет
             ->add('plainPassword', PasswordType::class)
         ;
     }


### PR DESCRIPTION
## DTO

Использовал [Data Transfer Object](https://ru.wikipedia.org/wiki/DTO) для формы. [Хорошая статья.](http://seyferseed.ru/ru/php/ne-ispolzujte-sushhnosti-v-formah-symfony-ispolzujte-luchshe-obekty-znacheniya.html#sthash.ZEKqJIjM.dpbs)

Это решило такие проблемы:
**1)** У меня в User нужно было в конструкторе указывать ник и пароль, приходилось писать так:
```php
// не понятно что
$user = new User('', '');

$form = $this->createForm(RegistrationFormType::class, $user);
$form->handleRequest($request);
```
Таким образом изначально Entity была всегда не валидной.  [Вот видео по теме.](https://youtu.be/rzGeNYC3oz0?t=1446)

> Сущность должна быть всегда валидной. Для сущности не должно быть возможным оказаться в невалидном состоянии.

**2)** Я избавился от связанности полей формы с атрибутами в Entity, например, plainPassword мог быть в Entity чтобы работать с формой, но поля в бд могло и не быть, это не правильно. Теперь я могу без проблем менять поля на какие захочу.

По идее сущность не должна зависеть и от ORM и DB, то есть не должно быть `@ORM\Column(...)` и т.д. 

## Domain Manager + Form Handler

Сделал регистрацию используя подходы из книги "Год с Symfony", с раздела "Тонкие контроллеры". 

---

Еще материал:
- [DTO vs POCO vs Value Object](https://habr.com/ru/post/268371/)
- [DTO](https://en.wikipedia.org/wiki/Data_transfer_object)
- [VO VS. DTO](http://www.adam-bien.com/roller/abien/entry/value_object_vs_data_transfer)
- [DDD](https://en.wikipedia.org/wiki/Domain-driven_design#Building_blocks)